### PR TITLE
Yoon

### DIFF
--- a/src/main/java/com/zerobase/together/controller/AuthController.java
+++ b/src/main/java/com/zerobase/together/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
   @PostMapping("/signin")
   public ResponseEntity<?> signin(@RequestBody AuthDto.SignIn request) {
     var user = this.userService.authenticate(request);
-    var token = this.tokenProvider.generateToken(user.getUserId());
+    var token = this.tokenProvider.generateToken(user.getUsername());
     return ResponseEntity.ok(token);
   }
 }

--- a/src/main/java/com/zerobase/together/controller/CommentController.java
+++ b/src/main/java/com/zerobase/together/controller/CommentController.java
@@ -7,42 +7,39 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/comment")
 @RequiredArgsConstructor
 public class CommentController {
 
   private final CommentService commentService;
 
-  @PostMapping("/create")
+  @PostMapping("/comment")
   public ResponseEntity<?> createComment(@RequestBody CommentDto request) {
     var result = this.commentService.createComment(request);
     return ResponseEntity.ok(result);
   }
 
-  @GetMapping("/read")
-  public ResponseEntity<?> readComments(@RequestParam Long postId) {
-    var result = this.commentService.readComments(postId);
+  @GetMapping("/comments/{postId}/{pageNum}")
+  public ResponseEntity<?> readComments(@PathVariable Long postId, @PathVariable Integer pageNum) {
+    var result = this.commentService.readComments(postId, pageNum);
     return ResponseEntity.ok(result);
   }
 
-  @PutMapping("/update")
-  public ResponseEntity<?> updateComment(@RequestParam Long commentId,
-      @RequestBody CommentDto request) {
-    var result = this.commentService.updateComment(commentId, request);
+  @PutMapping("/comment")
+  public ResponseEntity<?> updateComment(@RequestBody CommentDto request) {
+    var result = this.commentService.updateComment(request);
     return ResponseEntity.ok(result);
   }
 
-  @DeleteMapping("/delete")
-  public void deleteComment(@RequestParam Long commentId) {
+  @DeleteMapping("/comment/{commentId}")
+  public void deleteComment(@PathVariable Long commentId) {
     this.commentService.deleteComment(commentId);
   }
 

--- a/src/main/java/com/zerobase/together/controller/CommentController.java
+++ b/src/main/java/com/zerobase/together/controller/CommentController.java
@@ -1,0 +1,49 @@
+package com.zerobase.together.controller;
+
+import com.zerobase.together.dto.CommentDto;
+import com.zerobase.together.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/comment")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @PostMapping("/create")
+  public ResponseEntity<?> createComment(@RequestBody CommentDto request) {
+    var result = this.commentService.createComment(request);
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/read")
+  public ResponseEntity<?> readComments(@RequestParam Long postId) {
+    var result = this.commentService.readComments(postId);
+    return ResponseEntity.ok(result);
+  }
+
+  @PutMapping("/update")
+  public ResponseEntity<?> updateComment(@RequestParam Long commentId,
+      @RequestBody CommentDto request) {
+    var result = this.commentService.updateComment(commentId, request);
+    return ResponseEntity.ok(result);
+  }
+
+  @DeleteMapping("/delete")
+  public void deleteComment(@RequestParam Long commentId) {
+    this.commentService.deleteComment(commentId);
+  }
+
+}

--- a/src/main/java/com/zerobase/together/controller/HistoryController.java
+++ b/src/main/java/com/zerobase/together/controller/HistoryController.java
@@ -1,0 +1,26 @@
+package com.zerobase.together.controller;
+
+import com.zerobase.together.dto.HistoryDto;
+import com.zerobase.together.service.HistoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/history")
+@RequiredArgsConstructor
+public class HistoryController {
+
+  private final HistoryService historyService;
+
+  @GetMapping("/read")
+  public List<HistoryDto> readHistory() {
+    var result = this.historyService.readHistory();
+    return result;
+  }
+
+}

--- a/src/main/java/com/zerobase/together/controller/HistoryController.java
+++ b/src/main/java/com/zerobase/together/controller/HistoryController.java
@@ -6,20 +6,19 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/history")
 @RequiredArgsConstructor
 public class HistoryController {
 
   private final HistoryService historyService;
 
-  @GetMapping("/read")
-  public List<HistoryDto> readHistory() {
-    var result = this.historyService.readHistory();
+  @GetMapping("/historys/{pageNum}")
+  public List<HistoryDto> readHistory(@PathVariable Integer pageNum) {
+    var result = this.historyService.readHistory(pageNum);
     return result;
   }
 

--- a/src/main/java/com/zerobase/together/controller/PostController.java
+++ b/src/main/java/com/zerobase/together/controller/PostController.java
@@ -7,47 +7,45 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/post")
 @RequiredArgsConstructor
 public class PostController {
 
   private final PostService postService;
 
-  @PostMapping("/create")
+  @PostMapping("/post")
   public ResponseEntity<?> createPost(@RequestBody PostDto request) {
     var result = this.postService.createPost(request);
     return ResponseEntity.ok(result);
   }
 
-  @GetMapping("/read")
-  public ResponseEntity<?> readPost(@RequestParam Long postId) {
+  @GetMapping("/post/{postId}")
+  public ResponseEntity<?> readPost(@PathVariable Long postId) {
     var result = this.postService.readPost(postId);
     return ResponseEntity.ok(result);
   }
 
-  @GetMapping("/readAll")
-  public ResponseEntity<?> readAllPosts() {
-    var result = this.postService.readAllPosts();
+  @GetMapping("/posts/{pageNum}")
+  public ResponseEntity<?> readAllPosts(@PathVariable Integer pageNum) {
+    var result = this.postService.readPostPage(pageNum);
     return ResponseEntity.ok(result);
   }
 
-  @PutMapping("/update")
-  public ResponseEntity<?> updatePost(@RequestParam Long postId, @RequestBody PostDto request) {
-    var result = this.postService.updatePost(postId, request);
+  @PutMapping("/post")
+  public ResponseEntity<?> updatePost(@RequestBody PostDto request) {
+    var result = this.postService.updatePost(request);
     return ResponseEntity.ok(result);
   }
 
-  @DeleteMapping("/delete")
-  public void deletePost(@RequestParam Long postId) {
+  @DeleteMapping("/post/{postId}")
+  public void deletePost(@PathVariable Long postId) {
     this.postService.deletePost(postId);
   }
 

--- a/src/main/java/com/zerobase/together/controller/PostController.java
+++ b/src/main/java/com/zerobase/together/controller/PostController.java
@@ -1,0 +1,48 @@
+package com.zerobase.together.controller;
+
+import com.zerobase.together.dto.PostDto;
+import com.zerobase.together.service.PostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/post")
+@RequiredArgsConstructor
+public class PostController {
+
+  private final PostService postService;
+
+  @PostMapping("/create")
+  public ResponseEntity<?> createPost(@RequestBody PostDto request) {
+    var result = this.postService.createPost(request);
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/read")
+  public ResponseEntity<?> readPost() {
+    var result = this.postService.readPost();
+    return ResponseEntity.ok(result);
+  }
+
+  @PutMapping("/update")
+  public ResponseEntity<?> updatePost(@RequestParam Long postId, @RequestBody PostDto request) {
+    var result = this.postService.updatePost(postId, request);
+    return ResponseEntity.ok(result);
+  }
+
+  @DeleteMapping("/delete")
+  public void deletePost(@RequestParam Long postId) {
+    this.postService.deletePost(postId);
+  }
+
+}

--- a/src/main/java/com/zerobase/together/controller/PostController.java
+++ b/src/main/java/com/zerobase/together/controller/PostController.java
@@ -29,8 +29,14 @@ public class PostController {
   }
 
   @GetMapping("/read")
-  public ResponseEntity<?> readPost() {
-    var result = this.postService.readPost();
+  public ResponseEntity<?> readPost(@RequestParam Long postId) {
+    var result = this.postService.readPost(postId);
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/readAll")
+  public ResponseEntity<?> readAllPosts() {
+    var result = this.postService.readAllPosts();
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/com/zerobase/together/dto/AuthDto.java
+++ b/src/main/java/com/zerobase/together/dto/AuthDto.java
@@ -9,14 +9,14 @@ public class AuthDto {
   @Data
   public static class SignIn {
 
-    private String userId;
+    private String username;
     private String password;
   }
 
   @Data
   public static class SignUp {
 
-    private String userId;
+    private String username;
     private String password;
     private Long coupleId;
     private LocalDateTime createdDate;
@@ -25,12 +25,11 @@ public class AuthDto {
 
     public UserEntity toEntity() {
       return UserEntity.builder()
-          .userId(this.userId)
+          .username(this.username)
           .password(this.password)
           .coupleId(this.coupleId)
           .createdDateTime(this.createdDate)
           .modifiedDateTime(this.modifiedDate)
-          .removedDateTime(this.removedDate)
           .build();
     }
   }
@@ -38,9 +37,9 @@ public class AuthDto {
   @Data
   public static class SignUpWithPartner {
 
-    private String userId;
+    private String username;
     private String password;
-    private String partnerId;
+    private String partnername;
     private Long coupleId;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
@@ -49,12 +48,11 @@ public class AuthDto {
 
     public UserEntity toEntity() {
       return UserEntity.builder()
-          .userId(this.userId)
+          .username(this.username)
           .password(this.password)
           .coupleId(this.coupleId)
           .createdDateTime(this.createdDate)
           .modifiedDateTime(this.modifiedDate)
-          .removedDateTime(this.removedDate)
           .build();
     }
   }

--- a/src/main/java/com/zerobase/together/dto/CommentDto.java
+++ b/src/main/java/com/zerobase/together/dto/CommentDto.java
@@ -1,0 +1,30 @@
+package com.zerobase.together.dto;
+
+import com.zerobase.together.entity.CommentEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentDto {
+
+  private Long postId;
+  private Long coupleId;
+  private Long userId;
+  private String description;
+
+  public static CommentDto toDto(CommentEntity commentEntity) {
+    return CommentDto.builder()
+        .postId(commentEntity.getPostId())
+        .coupleId(commentEntity.getCoupleId())
+        .userId(commentEntity.getUserId())
+        .description(commentEntity.getDescription())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/together/dto/CommentDto.java
+++ b/src/main/java/com/zerobase/together/dto/CommentDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.together.dto;
 
 import com.zerobase.together.entity.CommentEntity;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,17 +15,23 @@ import lombok.Setter;
 @Builder
 public class CommentDto {
 
+  private Long commentId;
   private Long postId;
   private Long coupleId;
   private Long userId;
   private String description;
+  private LocalDateTime createdDateTime;
+  private LocalDateTime modifiedDateTime;
 
   public static CommentDto toDto(CommentEntity commentEntity) {
     return CommentDto.builder()
+        .commentId(commentEntity.getId())
         .postId(commentEntity.getPostId())
         .coupleId(commentEntity.getCoupleId())
         .userId(commentEntity.getUserId())
         .description(commentEntity.getDescription())
+        .createdDateTime(commentEntity.getCreatedDateTime())
+        .modifiedDateTime(commentEntity.getModifiedDateTime())
         .build();
   }
 }

--- a/src/main/java/com/zerobase/together/dto/CommentDto.java
+++ b/src/main/java/com/zerobase/together/dto/CommentDto.java
@@ -22,6 +22,7 @@ public class CommentDto {
   private String description;
   private LocalDateTime createdDateTime;
   private LocalDateTime modifiedDateTime;
+  private LocalDateTime deletedDateTime;
 
   public static CommentDto toDto(CommentEntity commentEntity) {
     return CommentDto.builder()
@@ -32,6 +33,7 @@ public class CommentDto {
         .description(commentEntity.getDescription())
         .createdDateTime(commentEntity.getCreatedDateTime())
         .modifiedDateTime(commentEntity.getModifiedDateTime())
+        .deletedDateTime(commentEntity.getDeletedDateTime())
         .build();
   }
 }

--- a/src/main/java/com/zerobase/together/dto/HistoryDto.java
+++ b/src/main/java/com/zerobase/together/dto/HistoryDto.java
@@ -1,0 +1,38 @@
+package com.zerobase.together.dto;
+
+import com.zerobase.together.entity.HistoryEntity;
+import com.zerobase.together.type.HistoryAction;
+import com.zerobase.together.type.HistoryTarget;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HistoryDto {
+
+  private Long coupleId;
+  private Long userId;
+  private Long targetId;
+  @Enumerated(EnumType.STRING)
+  private HistoryTarget historyTarget;
+  @Enumerated(EnumType.STRING)
+  private HistoryAction historyAction;
+
+  public static HistoryDto toDto(HistoryEntity historyEntity) {
+    return HistoryDto.builder()
+        .coupleId(historyEntity.getCoupleId())
+        .userId(historyEntity.getUserId())
+        .targetId(historyEntity.getTargetId())
+        .historyTarget(historyEntity.getHistoryTarget())
+        .historyAction(historyEntity.getHistoryAction())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/together/dto/HistoryDto.java
+++ b/src/main/java/com/zerobase/together/dto/HistoryDto.java
@@ -5,6 +5,7 @@ import com.zerobase.together.type.HistoryAction;
 import com.zerobase.together.type.HistoryTarget;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,7 @@ import lombok.Setter;
 @Builder
 public class HistoryDto {
 
+  private Long historyId;
   private Long coupleId;
   private Long userId;
   private Long targetId;
@@ -25,14 +27,21 @@ public class HistoryDto {
   private HistoryTarget historyTarget;
   @Enumerated(EnumType.STRING)
   private HistoryAction historyAction;
+  private String postContent;
+  private String commentContent;
+  private LocalDateTime createdDateTime;
 
   public static HistoryDto toDto(HistoryEntity historyEntity) {
     return HistoryDto.builder()
+        .historyId(historyEntity.getId())
         .coupleId(historyEntity.getCoupleId())
         .userId(historyEntity.getUserId())
         .targetId(historyEntity.getTargetId())
         .historyTarget(historyEntity.getHistoryTarget())
         .historyAction(historyEntity.getHistoryAction())
+        .postContent(historyEntity.getPostContent())
+        .commentContent(historyEntity.getCommentContent())
+        .createdDateTime(historyEntity.getCreatedDateTime())
         .build();
   }
 }

--- a/src/main/java/com/zerobase/together/dto/PostDto.java
+++ b/src/main/java/com/zerobase/together/dto/PostDto.java
@@ -19,8 +19,7 @@ public class PostDto {
   private String imgUrl;
   private String description;
 
-
-  public static PostDto toEntity(PostEntity postEntity) {
+  public static PostDto toDto(PostEntity postEntity) {
     return PostDto.builder()
         .coupleId(postEntity.getCoupleId())
         .userId(postEntity.getUserId())

--- a/src/main/java/com/zerobase/together/dto/PostDto.java
+++ b/src/main/java/com/zerobase/together/dto/PostDto.java
@@ -1,0 +1,32 @@
+package com.zerobase.together.dto;
+
+import com.zerobase.together.entity.PostEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PostDto {
+
+  private Long coupleId;
+  private Long userId;
+  private String imgUrl;
+  private String description;
+
+
+  public static PostDto toEntity(PostEntity postEntity) {
+    return PostDto.builder()
+        .coupleId(postEntity.getCoupleId())
+        .userId(postEntity.getUserId())
+        .imgUrl(postEntity.getImgUrl())
+        .description(postEntity.getDescription())
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/together/dto/PostDto.java
+++ b/src/main/java/com/zerobase/together/dto/PostDto.java
@@ -22,6 +22,7 @@ public class PostDto {
   private String description;
   private LocalDateTime createdDateTime;
   private LocalDateTime modifiedDateTime;
+  private LocalDateTime deletedDateTime;
 
   public static PostDto toDto(PostEntity postEntity) {
     return PostDto.builder()
@@ -32,6 +33,7 @@ public class PostDto {
         .description(postEntity.getDescription())
         .createdDateTime(postEntity.getCreatedDateTime())
         .modifiedDateTime(postEntity.getModifiedDateTime())
+        .deletedDateTime(postEntity.getDeletedDateTime())
         .build();
   }
 

--- a/src/main/java/com/zerobase/together/dto/PostDto.java
+++ b/src/main/java/com/zerobase/together/dto/PostDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.together.dto;
 
 import com.zerobase.together.entity.PostEntity;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,17 +15,23 @@ import lombok.Setter;
 @Builder
 public class PostDto {
 
+  private Long postId;
   private Long coupleId;
   private Long userId;
   private String imgUrl;
   private String description;
+  private LocalDateTime createdDateTime;
+  private LocalDateTime modifiedDateTime;
 
   public static PostDto toDto(PostEntity postEntity) {
     return PostDto.builder()
+        .postId(postEntity.getId())
         .coupleId(postEntity.getCoupleId())
         .userId(postEntity.getUserId())
         .imgUrl(postEntity.getImgUrl())
         .description(postEntity.getDescription())
+        .createdDateTime(postEntity.getCreatedDateTime())
+        .modifiedDateTime(postEntity.getModifiedDateTime())
         .build();
   }
 

--- a/src/main/java/com/zerobase/together/dto/UserDto.java
+++ b/src/main/java/com/zerobase/together/dto/UserDto.java
@@ -19,13 +19,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class UserDto implements UserDetails {
 
   private Long coupleId;
-  private String userId;
+  private String username;
 
 
   public static UserDto fromEntity(UserEntity userEntity) {
     return UserDto.builder()
         .coupleId(userEntity.getCoupleId())
-        .userId(userEntity.getUserId())
+        .username(userEntity.getUsername())
         .build();
   }
 
@@ -41,6 +41,6 @@ public class UserDto implements UserDetails {
 
   @Override
   public String getUsername() {
-    return this.userId;
+    return this.username;
   }
 }

--- a/src/main/java/com/zerobase/together/dto/UserDto.java
+++ b/src/main/java/com/zerobase/together/dto/UserDto.java
@@ -41,6 +41,6 @@ public class UserDto implements UserDetails {
 
   @Override
   public String getUsername() {
-    return "";
+    return this.userId;
   }
 }

--- a/src/main/java/com/zerobase/together/entity/CommentEntity.java
+++ b/src/main/java/com/zerobase/together/entity/CommentEntity.java
@@ -1,0 +1,42 @@
+package com.zerobase.together.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "comment")
+@EntityListeners(AuditingEntityListener.class)
+public class CommentEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private Long postId;
+  private Long coupleId;
+  private Long userId;
+  @Column(columnDefinition = "TEXT")
+  private String description;
+  @CreatedDate
+  private LocalDateTime createdDateTime;
+  @LastModifiedDate
+  private LocalDateTime modifiedDateTime;
+}

--- a/src/main/java/com/zerobase/together/entity/CommentEntity.java
+++ b/src/main/java/com/zerobase/together/entity/CommentEntity.java
@@ -39,4 +39,5 @@ public class CommentEntity {
   private LocalDateTime createdDateTime;
   @LastModifiedDate
   private LocalDateTime modifiedDateTime;
+  private LocalDateTime deletedDateTime;
 }

--- a/src/main/java/com/zerobase/together/entity/CoupleEntity.java
+++ b/src/main/java/com/zerobase/together/entity/CoupleEntity.java
@@ -33,7 +33,6 @@ public class CoupleEntity {
   private LocalDateTime createdDateTime;
   @LastModifiedDate
   private LocalDateTime modifiedDateTime;
-  private LocalDateTime removedDateTime;
   private boolean authorized;
 
 }

--- a/src/main/java/com/zerobase/together/entity/HistoryEntity.java
+++ b/src/main/java/com/zerobase/together/entity/HistoryEntity.java
@@ -2,6 +2,7 @@ package com.zerobase.together.entity;
 
 import com.zerobase.together.type.HistoryAction;
 import com.zerobase.together.type.HistoryTarget;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -39,6 +40,10 @@ public class HistoryEntity {
   private HistoryTarget historyTarget;
   @Enumerated(EnumType.STRING)
   private HistoryAction historyAction;
+  @Column(columnDefinition = "TEXT")
+  private String postContent;
+  @Column(columnDefinition = "TEXT")
+  private String commentContent;
   @CreatedDate
   private LocalDateTime createdDateTime;
 

--- a/src/main/java/com/zerobase/together/entity/HistoryEntity.java
+++ b/src/main/java/com/zerobase/together/entity/HistoryEntity.java
@@ -1,0 +1,45 @@
+package com.zerobase.together.entity;
+
+import com.zerobase.together.type.HistoryAction;
+import com.zerobase.together.type.HistoryTarget;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "history")
+@EntityListeners(AuditingEntityListener.class)
+public class HistoryEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private Long coupleId;
+  private Long userId;
+  private Long targetId;
+  @Enumerated(EnumType.STRING)
+  private HistoryTarget historyTarget;
+  @Enumerated(EnumType.STRING)
+  private HistoryAction historyAction;
+  @CreatedDate
+  private LocalDateTime createdDateTime;
+
+}

--- a/src/main/java/com/zerobase/together/entity/PostEntity.java
+++ b/src/main/java/com/zerobase/together/entity/PostEntity.java
@@ -1,0 +1,44 @@
+package com.zerobase.together.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "post")
+@EntityListeners(AuditingEntityListener.class)
+public class PostEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private Long coupleId;
+  private Long userId;
+  @Column(length = 32)
+  private String imgUrl;
+  @Column(columnDefinition = "TEXT")
+  private String description;
+  @CreatedDate
+  private LocalDateTime createdDateTime;
+  @LastModifiedDate
+  private LocalDateTime modifiedDateTime;
+  private LocalDateTime removedDateTime;
+}

--- a/src/main/java/com/zerobase/together/entity/PostEntity.java
+++ b/src/main/java/com/zerobase/together/entity/PostEntity.java
@@ -40,4 +40,5 @@ public class PostEntity {
   private LocalDateTime createdDateTime;
   @LastModifiedDate
   private LocalDateTime modifiedDateTime;
+  private LocalDateTime deletedDateTime;
 }

--- a/src/main/java/com/zerobase/together/entity/PostEntity.java
+++ b/src/main/java/com/zerobase/together/entity/PostEntity.java
@@ -40,5 +40,4 @@ public class PostEntity {
   private LocalDateTime createdDateTime;
   @LastModifiedDate
   private LocalDateTime modifiedDateTime;
-  private LocalDateTime removedDateTime;
 }

--- a/src/main/java/com/zerobase/together/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/together/entity/UserEntity.java
@@ -30,13 +30,11 @@ public class UserEntity {
   private Long id;
   private Long coupleId;
   @Column(unique = true, length = 32)
-  private String userId;
+  private String username;
   @Column(length = 64)
   private String password;
   @CreatedDate
   private LocalDateTime createdDateTime;
   @LastModifiedDate
   private LocalDateTime modifiedDateTime;
-  private LocalDateTime removedDateTime;
-
 }

--- a/src/main/java/com/zerobase/together/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/together/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package com.zerobase.together.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -28,7 +29,9 @@ public class UserEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   private Long coupleId;
+  @Column(unique = true, length = 32)
   private String userId;
+  @Column(length = 64)
   private String password;
   @CreatedDate
   private LocalDateTime createdDateTime;

--- a/src/main/java/com/zerobase/together/repository/CommentRepository.java
+++ b/src/main/java/com/zerobase/together/repository/CommentRepository.java
@@ -1,10 +1,11 @@
 package com.zerobase.together.repository;
 
 import com.zerobase.together.entity.CommentEntity;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
-  List<CommentEntity> getCommentEntitiesByPostId(Long postId);
+  Page<CommentEntity> findAllByPostIdOrderByCreatedDateTimeDesc(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/together/repository/CommentRepository.java
+++ b/src/main/java/com/zerobase/together/repository/CommentRepository.java
@@ -1,11 +1,13 @@
 package com.zerobase.together.repository;
 
 import com.zerobase.together.entity.CommentEntity;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
-  Page<CommentEntity> findAllByPostIdOrderByCreatedDateTimeDesc(Long postId, Pageable pageable);
+  Page<CommentEntity> findAllByPostIdAndDeletedDateTimeOrderByCreatedDateTimeDesc(Long postId,
+      LocalDateTime deletedDateTime, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/together/repository/CommentRepository.java
+++ b/src/main/java/com/zerobase/together/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.together.repository;
+
+import com.zerobase.together.entity.CommentEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+
+  List<CommentEntity> getCommentEntitiesByPostId(Long postId);
+}

--- a/src/main/java/com/zerobase/together/repository/HistoryRepository.java
+++ b/src/main/java/com/zerobase/together/repository/HistoryRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.together.repository;
+
+import com.zerobase.together.entity.HistoryEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
+
+  List<HistoryEntity> getHistoryEntitiesByCoupleId(Long coupleId);
+}

--- a/src/main/java/com/zerobase/together/repository/HistoryRepository.java
+++ b/src/main/java/com/zerobase/together/repository/HistoryRepository.java
@@ -1,10 +1,14 @@
 package com.zerobase.together.repository;
 
 import com.zerobase.together.entity.HistoryEntity;
-import java.util.List;
+import com.zerobase.together.type.HistoryTarget;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
 
-  List<HistoryEntity> getHistoryEntitiesByCoupleId(Long coupleId);
+  void deleteAllByHistoryTargetAndTargetId(HistoryTarget historyTarget, Long targetId);
+
+  Page<HistoryEntity> findAllByCoupleIdOrderByCreatedDateTimeDesc(Long coupleId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/together/repository/PostRepository.java
+++ b/src/main/java/com/zerobase/together/repository/PostRepository.java
@@ -1,10 +1,11 @@
 package com.zerobase.together.repository;
 
 import com.zerobase.together.entity.PostEntity;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
-  List<PostEntity> getPostEntitiesByCoupleId(Long coupleId);
+  Page<PostEntity> findAllByCoupleIdOrderByCreatedDateTimeDesc(Long coupleId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/together/repository/PostRepository.java
+++ b/src/main/java/com/zerobase/together/repository/PostRepository.java
@@ -1,11 +1,14 @@
 package com.zerobase.together.repository;
 
 import com.zerobase.together.entity.PostEntity;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
-  Page<PostEntity> findAllByCoupleIdOrderByCreatedDateTimeDesc(Long coupleId, Pageable pageable);
+
+  Page<PostEntity> findAllByCoupleIdAndDeletedDateTimeOrderByCreatedDateTimeDesc(Long coupleId,
+      LocalDateTime deletedDateTime, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/together/repository/PostRepository.java
+++ b/src/main/java/com/zerobase/together/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.together.repository;
+
+import com.zerobase.together.entity.PostEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+  List<PostEntity> getPostEntitiesByCoupleId(Long coupleId);
+}

--- a/src/main/java/com/zerobase/together/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/together/repository/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-  Optional<UserEntity> findByUserId(String userId);
+  Optional<UserEntity> findByUsername(String username);
 
-  boolean existsByUserId(String userId);
+  boolean existsByUsername(String username);
 }

--- a/src/main/java/com/zerobase/together/service/CommentService.java
+++ b/src/main/java/com/zerobase/together/service/CommentService.java
@@ -1,12 +1,15 @@
 package com.zerobase.together.service;
 
 import com.zerobase.together.dto.CommentDto;
+import com.zerobase.together.dto.HistoryDto;
 import com.zerobase.together.entity.CommentEntity;
 import com.zerobase.together.entity.PostEntity;
 import com.zerobase.together.entity.UserEntity;
 import com.zerobase.together.repository.CommentRepository;
 import com.zerobase.together.repository.PostRepository;
 import com.zerobase.together.repository.UserRepository;
+import com.zerobase.together.type.HistoryAction;
+import com.zerobase.together.type.HistoryTarget;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +26,7 @@ public class CommentService {
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
   private final PostRepository postRepository;
+  private final HistoryService historyService;
 
   public CommentDto createComment(CommentDto request) {
     UserEntity user = getLoginUser();
@@ -31,12 +35,23 @@ public class CommentService {
     if (user.getCoupleId() != post.getCoupleId()) {
       throw new RuntimeException("댓글 작성 권한이 없습니다.");
     }
-    return CommentDto.toDto(this.commentRepository.save(CommentEntity.builder()
+
+    CommentEntity commentEntity = this.commentRepository.save(CommentEntity.builder()
         .postId(request.getPostId())
         .coupleId(user.getCoupleId())
         .userId(user.getId())
         .description(request.getDescription())
-        .build()));
+        .build());
+
+    this.historyService.createHistory(HistoryDto.builder()
+        .coupleId(user.getCoupleId())
+        .userId(user.getId())
+        .targetId(commentEntity.getId())
+        .historyTarget(HistoryTarget.COMMENT)
+        .historyAction(HistoryAction.CREATE)
+        .build());
+
+    return CommentDto.toDto(commentEntity);
   }
 
   public List<CommentDto> readComments(Long postId) {
@@ -57,6 +72,15 @@ public class CommentService {
       throw new RuntimeException("댓글 수정 권한이 없습니다.");
     }
     commentEntity.setDescription(request.getDescription());
+
+    this.historyService.createHistory(HistoryDto.builder()
+        .coupleId(user.getCoupleId())
+        .userId(user.getId())
+        .targetId(commentEntity.getId())
+        .historyTarget(HistoryTarget.COMMENT)
+        .historyAction(HistoryAction.UPDATE)
+        .build());
+
     return CommentDto.toDto(this.commentRepository.save(commentEntity));
   }
 
@@ -67,7 +91,15 @@ public class CommentService {
     if (user.getId() != commentEntity.getUserId()) {
       throw new RuntimeException("댓글 삭제 권한이 없습니다.");
     }
+
     this.commentRepository.deleteById(commentId);
+    this.historyService.createHistory(HistoryDto.builder()
+        .coupleId(user.getCoupleId())
+        .userId(user.getId())
+        .targetId(null)
+        .historyTarget(HistoryTarget.COMMENT)
+        .historyAction(HistoryAction.DELETE)
+        .build());
   }
 
   private UserEntity getLoginUser() {

--- a/src/main/java/com/zerobase/together/service/CommentService.java
+++ b/src/main/java/com/zerobase/together/service/CommentService.java
@@ -1,0 +1,79 @@
+package com.zerobase.together.service;
+
+import com.zerobase.together.dto.CommentDto;
+import com.zerobase.together.entity.CommentEntity;
+import com.zerobase.together.entity.PostEntity;
+import com.zerobase.together.entity.UserEntity;
+import com.zerobase.together.repository.CommentRepository;
+import com.zerobase.together.repository.PostRepository;
+import com.zerobase.together.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+  private final UserRepository userRepository;
+  private final PostRepository postRepository;
+
+  public CommentDto createComment(CommentDto request) {
+    UserEntity user = getLoginUser();
+    PostEntity post = postRepository.findById(request.getPostId())
+        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+    if (user.getCoupleId() != post.getCoupleId()) {
+      throw new RuntimeException("댓글 작성 권한이 없습니다.");
+    }
+    return CommentDto.toDto(this.commentRepository.save(CommentEntity.builder()
+        .postId(request.getPostId())
+        .coupleId(user.getCoupleId())
+        .userId(user.getId())
+        .description(request.getDescription())
+        .build()));
+  }
+
+  public List<CommentDto> readComments(Long postId) {
+    UserEntity user = getLoginUser();
+    if (user.getCoupleId() != this.postRepository.findById(postId).get().getCoupleId()) {
+      throw new RuntimeException("댓글 조회 권한이 없습니다.");
+    }
+    return this.commentRepository.getCommentEntitiesByPostId(postId).stream()
+        .map(CommentDto::toDto)
+        .toList();
+  }
+
+  public CommentDto updateComment(Long commentId, CommentDto request) {
+    UserEntity user = getLoginUser();
+    CommentEntity commentEntity = this.commentRepository.findById(commentId)
+        .orElseThrow(() -> new RuntimeException("해당 댓글이 존재하지 않습니다."));
+    if (user.getId() != commentEntity.getUserId()) {
+      throw new RuntimeException("댓글 수정 권한이 없습니다.");
+    }
+    commentEntity.setDescription(request.getDescription());
+    return CommentDto.toDto(this.commentRepository.save(commentEntity));
+  }
+
+  public void deleteComment(Long commentId) {
+    UserEntity user = getLoginUser();
+    CommentEntity commentEntity = this.commentRepository.findById(commentId)
+        .orElseThrow(() -> new RuntimeException("해당 댓글이 존재하지 않습니다."));
+    if (user.getId() != commentEntity.getUserId()) {
+      throw new RuntimeException("댓글 삭제 권한이 없습니다.");
+    }
+    this.commentRepository.deleteById(commentId);
+  }
+
+  private UserEntity getLoginUser() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    return this.userRepository.findByUsername(userDetails.getUsername())
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+  }
+}

--- a/src/main/java/com/zerobase/together/service/HistoryService.java
+++ b/src/main/java/com/zerobase/together/service/HistoryService.java
@@ -5,9 +5,13 @@ import com.zerobase.together.entity.HistoryEntity;
 import com.zerobase.together.entity.UserEntity;
 import com.zerobase.together.repository.HistoryRepository;
 import com.zerobase.together.repository.UserRepository;
+import com.zerobase.together.type.HistoryTarget;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -26,15 +30,31 @@ public class HistoryService {
         .coupleId(historyDto.getCoupleId())
         .userId(historyDto.getUserId())
         .targetId(historyDto.getTargetId())
+        .postContent(historyDto.getPostContent())
+        .commentContent(historyDto.getCommentContent())
         .historyTarget(historyDto.getHistoryTarget())
         .historyAction(historyDto.getHistoryAction())
         .build());
   }
 
-  public List<HistoryDto> readHistory() {
+  public List<HistoryDto> readHistory(Integer pageNum) {
     UserEntity user = getLoginUser();
-    return this.historyRepository.getHistoryEntitiesByCoupleId(user.getCoupleId()).stream()
-        .map(HistoryDto::toDto).toList();
+    Pageable pageable = PageRequest.of(pageNum, 10);
+    Page<HistoryEntity> result = historyRepository.findAllByCoupleIdOrderByCreatedDateTimeDesc(
+        user.getCoupleId(),
+        pageable);
+    return result.stream().map(HistoryDto::toDto).toList();
+  }
+
+  public void deleteHistory(HistoryTarget historyTarget, Long targetId) {
+    this.historyRepository.deleteAllByHistoryTargetAndTargetId(historyTarget, targetId);
+  }
+
+  public String shortenContent(String content) {
+    if (content.length() < 10) {
+      return content;
+    }
+    return content.substring(0, 10) + "...";
   }
 
   private UserEntity getLoginUser() {

--- a/src/main/java/com/zerobase/together/service/HistoryService.java
+++ b/src/main/java/com/zerobase/together/service/HistoryService.java
@@ -1,0 +1,46 @@
+package com.zerobase.together.service;
+
+import com.zerobase.together.dto.HistoryDto;
+import com.zerobase.together.entity.HistoryEntity;
+import com.zerobase.together.entity.UserEntity;
+import com.zerobase.together.repository.HistoryRepository;
+import com.zerobase.together.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+  private final HistoryRepository historyRepository;
+  private final UserRepository userRepository;
+
+  public void createHistory(HistoryDto historyDto) {
+    this.historyRepository.save(HistoryEntity.builder()
+        .coupleId(historyDto.getCoupleId())
+        .userId(historyDto.getUserId())
+        .targetId(historyDto.getTargetId())
+        .historyTarget(historyDto.getHistoryTarget())
+        .historyAction(historyDto.getHistoryAction())
+        .build());
+  }
+
+  public List<HistoryDto> readHistory() {
+    UserEntity user = getLoginUser();
+    return this.historyRepository.getHistoryEntitiesByCoupleId(user.getCoupleId()).stream()
+        .map(HistoryDto::toDto).toList();
+  }
+
+  private UserEntity getLoginUser() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    return this.userRepository.findByUsername(userDetails.getUsername())
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+  }
+}

--- a/src/main/java/com/zerobase/together/service/HistoryService.java
+++ b/src/main/java/com/zerobase/together/service/HistoryService.java
@@ -5,7 +5,6 @@ import com.zerobase.together.entity.HistoryEntity;
 import com.zerobase.together.entity.UserEntity;
 import com.zerobase.together.repository.HistoryRepository;
 import com.zerobase.together.repository.UserRepository;
-import com.zerobase.together.type.HistoryTarget;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,10 +43,6 @@ public class HistoryService {
         user.getCoupleId(),
         pageable);
     return result.stream().map(HistoryDto::toDto).toList();
-  }
-
-  public void deleteHistory(HistoryTarget historyTarget, Long targetId) {
-    this.historyRepository.deleteAllByHistoryTargetAndTargetId(historyTarget, targetId);
   }
 
   public String shortenContent(String content) {

--- a/src/main/java/com/zerobase/together/service/PostService.java
+++ b/src/main/java/com/zerobase/together/service/PostService.java
@@ -22,54 +22,58 @@ public class PostService {
   private final UserRepository userRepository;
 
   public PostDto createPost(PostDto post) {
-    return PostDto.toEntity(this.postRepository.save(PostEntity.builder()
-        .coupleId(post.getCoupleId())
-        .userId(post.getUserId())
+    UserEntity user = getLoginUser();
+    return PostDto.toDto(this.postRepository.save(PostEntity.builder()
+        .coupleId(user.getCoupleId())
+        .userId(user.getId())
         .imgUrl(post.getImgUrl())
         .description(post.getDescription())
         .build()
     ));
   }
 
-  public List<PostDto> readPost() {
-    String userId = getLoginUserId();
-    UserEntity user = this.userRepository.findByUserId(userId)
-        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+  public PostDto readPost(Long postId) {
+    UserEntity user = getLoginUser();
+    PostEntity postEntity = this.postRepository.findById(postId)
+        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+    if (postEntity.getCoupleId() != user.getCoupleId()) {
+      throw new RuntimeException("포스트를 읽을 권한이 없습니다.");
+    }
+    return PostDto.toDto(postEntity);
+  }
+
+  public List<PostDto> readAllPosts() {
+    UserEntity user = getLoginUser();
     return this.postRepository.getPostEntitiesByCoupleId(user.getCoupleId()).stream()
-        .map(PostDto::toEntity).toList();
+        .map(PostDto::toDto).toList();
   }
 
   public PostDto updatePost(Long postId, PostDto post) {
-    String userId = getLoginUserId();
-    UserEntity user = this.userRepository.findByUserId(userId)
-        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+    UserEntity user = getLoginUser();
     PostEntity postEntity = this.postRepository.findById(postId)
         .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
-    if (!postEntity.getUserId().equals(user.getId())) {
+    if (postEntity.getUserId() != user.getId()) {
       throw new RuntimeException("포스트 작성자가 아닙니다.");
     }
     postEntity.setImgUrl(post.getImgUrl());
     postEntity.setDescription(post.getDescription());
-    return PostDto.toEntity(this.postRepository.save(postEntity));
+    return PostDto.toDto(this.postRepository.save(postEntity));
   }
 
   public void deletePost(Long postId) {
-    //TODO update와 로그인 유저 확인하는 부분 중복없애는 방법 고민
-    String userId = getLoginUserId();
-    UserEntity user = this.userRepository.findByUserId(userId)
-        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+    UserEntity user = getLoginUser();
     PostEntity postEntity = this.postRepository.findById(postId)
         .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
-    System.out.println(postEntity.getId());
-    if (!postEntity.getUserId().equals(user.getId())) {
+    if (user.getId() != postEntity.getUserId()) {
       throw new RuntimeException("포스트 작성자가 아닙니다.");
     }
     this.postRepository.deleteById(postId);
   }
 
-  private String getLoginUserId() {
+  private UserEntity getLoginUser() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-    return userDetails.getUsername();
+    return this.userRepository.findByUsername(userDetails.getUsername())
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
   }
 }

--- a/src/main/java/com/zerobase/together/service/PostService.java
+++ b/src/main/java/com/zerobase/together/service/PostService.java
@@ -1,0 +1,75 @@
+package com.zerobase.together.service;
+
+import com.zerobase.together.dto.PostDto;
+import com.zerobase.together.entity.PostEntity;
+import com.zerobase.together.entity.UserEntity;
+import com.zerobase.together.repository.PostRepository;
+import com.zerobase.together.repository.UserRepository;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class PostService {
+
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
+
+  public PostDto createPost(PostDto post) {
+    return PostDto.toEntity(this.postRepository.save(PostEntity.builder()
+        .coupleId(post.getCoupleId())
+        .userId(post.getUserId())
+        .imgUrl(post.getImgUrl())
+        .description(post.getDescription())
+        .build()
+    ));
+  }
+
+  public List<PostDto> readPost() {
+    String userId = getLoginUserId();
+    UserEntity user = this.userRepository.findByUserId(userId)
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+    return this.postRepository.getPostEntitiesByCoupleId(user.getCoupleId()).stream()
+        .map(PostDto::toEntity).toList();
+  }
+
+  public PostDto updatePost(Long postId, PostDto post) {
+    String userId = getLoginUserId();
+    UserEntity user = this.userRepository.findByUserId(userId)
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+    PostEntity postEntity = this.postRepository.findById(postId)
+        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+    if (!postEntity.getUserId().equals(user.getId())) {
+      throw new RuntimeException("포스트 작성자가 아닙니다.");
+    }
+    postEntity.setImgUrl(post.getImgUrl());
+    postEntity.setDescription(post.getDescription());
+    return PostDto.toEntity(this.postRepository.save(postEntity));
+  }
+
+  public void deletePost(Long postId) {
+    //TODO update와 로그인 유저 확인하는 부분 중복없애는 방법 고민
+    String userId = getLoginUserId();
+    UserEntity user = this.userRepository.findByUserId(userId)
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+    PostEntity postEntity = this.postRepository.findById(postId)
+        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+    System.out.println(postEntity.getId());
+    if (!postEntity.getUserId().equals(user.getId())) {
+      throw new RuntimeException("포스트 작성자가 아닙니다.");
+    }
+    this.postRepository.deleteById(postId);
+  }
+
+  private String getLoginUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    return userDetails.getUsername();
+  }
+}

--- a/src/main/java/com/zerobase/together/service/UserService.java
+++ b/src/main/java/com/zerobase/together/service/UserService.java
@@ -32,8 +32,8 @@ public class UserService implements UserDetailsService {
    */
   public UserDto register(AuthDto.SignUp user) {
 
-    if (this.userRepository.existsByUserId(user.getUserId())) {
-      throw new RuntimeException("이미 사용중인 아이디 입니다. -> " + user.getUserId());
+    if (this.userRepository.existsByUsername(user.getUsername())) {
+      throw new RuntimeException("이미 사용중인 아이디 입니다. -> " + user.getUsername());
     }
 
     CoupleEntity coupleEntity = coupleRepository.save(new CoupleEntity());
@@ -51,18 +51,18 @@ public class UserService implements UserDetailsService {
    * @return 저장된 회원 정보
    */
   public UserDto registerWithPartner(SignUpWithPartner user) {
-    if (this.userRepository.existsByUserId(user.getUserId())) {
-      throw new RuntimeException("이미 사용중인 아이디 입니다. -> " + user.getUserId());
+    if (this.userRepository.existsByUsername(user.getUsername())) {
+      throw new RuntimeException("이미 사용중인 아이디 입니다. -> " + user.getUsername());
     }
 
-    UserEntity partner = this.userRepository.findByUserId(user.getPartnerId())
+    UserEntity partner = this.userRepository.findByUsername(user.getPartnername())
         .orElseThrow(
-            () -> new UsernameNotFoundException("파트너가 존재하지 않습니다. -> " + user.getPartnerId()));
+            () -> new UsernameNotFoundException("파트너가 존재하지 않습니다. -> " + user.getPartnername()));
     user.setCoupleId(partner.getCoupleId());
     user.setPassword(this.passwordEncoder.encode(user.getPassword()));
 
     CoupleEntity coupleEntity = coupleRepository.findById(partner.getCoupleId())
-        .orElseThrow(() -> new RuntimeException("커플아이디가 존재하지 않습니다. -> " + user.getUserId()));
+        .orElseThrow(() -> new RuntimeException("커플아이디가 존재하지 않습니다. -> " + user.getCoupleId()));
     coupleEntity.setAuthorized(true);
     coupleRepository.save(coupleEntity);
 
@@ -76,7 +76,7 @@ public class UserService implements UserDetailsService {
    * @return 로그인된 회원 정보
    */
   public UserDto authenticate(AuthDto.SignIn loginUser) {
-    var user = this.userRepository.findByUserId(loginUser.getUserId())
+    var user = this.userRepository.findByUsername(loginUser.getUsername())
         .orElseThrow(() -> new RuntimeException("존재하지 않는 ID 입니다."));
 
     if (!this.passwordEncoder.matches(loginUser.getPassword(), user.getPassword())) {
@@ -84,7 +84,7 @@ public class UserService implements UserDetailsService {
     }
 
     CoupleEntity coupleEntity = coupleRepository.findById(user.getCoupleId())
-        .orElseThrow(() -> new RuntimeException("커플아이디가 존재하지 않습니다. -> " + user.getUserId()));
+        .orElseThrow(() -> new RuntimeException("커플아이디가 존재하지 않습니다. -> " + user.getCoupleId()));
 
     if (!coupleEntity.isAuthorized()) {
       throw new RuntimeException("상대방이 가입하지 않았습니다.");
@@ -95,7 +95,7 @@ public class UserService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-    return UserDto.fromEntity(this.userRepository.findByUserId(userId)
+    return UserDto.fromEntity(this.userRepository.findByUsername(userId)
         .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다.")));
   }
 }

--- a/src/main/java/com/zerobase/together/type/HistoryAction.java
+++ b/src/main/java/com/zerobase/together/type/HistoryAction.java
@@ -1,0 +1,7 @@
+package com.zerobase.together.type;
+
+public enum HistoryAction {
+  CREATE,
+  UPDATE,
+  DELETE
+}

--- a/src/main/java/com/zerobase/together/type/HistoryTarget.java
+++ b/src/main/java/com/zerobase/together/type/HistoryTarget.java
@@ -1,0 +1,6 @@
+package com.zerobase.together.type;
+
+public enum HistoryTarget {
+  POST,
+  COMMENT
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

**AS-IS**
게시글,댓글은 같은 커플 코드인 사람만 조회를 할 수 있고 수정,삭제는 작성자만 할 수 있도록 구현했습니다.
게시글,댓글을 작성,수정,삭제하는 경우에 활동로그가 남도록 구현했습니다.

**TO-BE**
활동로그를 남기는 부분이나 로그인된 유저를 확인하는 부분을 AOP를 이용해 뺄 수도 있을 것 같습니다.
로그인된 유저를 매번 db에 조회해서 맞는지 검색하는 것을 줄이기 위해 현재는 username만 포함된 jwt토큰에 유저 정보를 더 넣어줘서 관련 조회 시간을 줄일 수도 있을 것 같습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] API 테스트 : 포스트맨을 통해 모든 API들이 정상 작동하는 것을 확인했습니다.