### PR TITLE
feat: 같은 커플Id인 사람들끼리 채팅 기능 추가, 채팅내역 조회 기능 추가, 채팅 테스트를 위한 임시 페이지와 보안 설…

### DIFF
--- a/src/main/java/com/zerobase/together/config/WebSocketConfig.java
+++ b/src/main/java/com/zerobase/together/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.zerobase.together.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    config.enableSimpleBroker("/topic"); // 클라이언트에게 메시지 브로드캐스트
+    config.setApplicationDestinationPrefixes("/app"); // 클라이언트 메시지 라우팅
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws/chat")
+        .withSockJS(); // WebSocket 엔드포인트
+  }
+}

--- a/src/main/java/com/zerobase/together/controller/ChatController.java
+++ b/src/main/java/com/zerobase/together/controller/ChatController.java
@@ -1,0 +1,40 @@
+package com.zerobase.together.controller;
+
+import com.zerobase.together.dto.ChatDto;
+import com.zerobase.together.service.ChatService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+  private final SimpMessagingTemplate messagingTemplate;
+  private final ChatService chatService;
+
+  @MessageMapping("/send") // 클라이언트가 /app/send로 보낸 메시지를 수신
+  @SendTo("/topic/messages") // 구독자에게 /topic/messages로 메시지를 브로드캐스트
+  public void sendMessage(ChatDto message) {
+    String destination = "/topic/messages/" + message.getCoupleId();
+    this.messagingTemplate.convertAndSend(destination, message);
+    this.chatService.saveChat(message);
+  }
+
+  @GetMapping("/chats/{pageNum}")
+  public ResponseEntity<List<ChatDto>> getChats(@PathVariable Integer pageNum) {
+    var result = this.chatService.getChats(pageNum);
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/chat")
+  public String chatPage() {
+    return "chat.html";
+  }
+}

--- a/src/main/java/com/zerobase/together/dto/ChatDto.java
+++ b/src/main/java/com/zerobase/together/dto/ChatDto.java
@@ -1,0 +1,31 @@
+package com.zerobase.together.dto;
+
+import com.zerobase.together.entity.ChatEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatDto {
+
+  private Long coupleId;
+  private String senderId;
+  private String content;
+  private LocalDateTime createdDateTime;
+
+  public static ChatDto toDto(ChatEntity chatEntity) {
+    return ChatDto.builder()
+        .coupleId(chatEntity.getCoupleId())
+        .senderId(chatEntity.getSenderId())
+        .content(chatEntity.getContent())
+        .createdDateTime(chatEntity.getCreatedDateTime())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/together/entity/ChatEntity.java
+++ b/src/main/java/com/zerobase/together/entity/ChatEntity.java
@@ -1,0 +1,35 @@
+package com.zerobase.together.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "chat")
+@EntityListeners(AuditingEntityListener.class)
+public class ChatEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private Long coupleId;
+  private String senderId;
+  private String content;
+  @CreatedDate
+  private LocalDateTime createdDateTime;
+
+}

--- a/src/main/java/com/zerobase/together/repository/ChatRepository.java
+++ b/src/main/java/com/zerobase/together/repository/ChatRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.together.repository;
+
+import com.zerobase.together.entity.ChatEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
+
+  Page<ChatEntity> findAllByCoupleIdOrderByCreatedDateTimeDesc(Long coupleId, Pageable pageable);
+}

--- a/src/main/java/com/zerobase/together/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/together/security/SecurityConfiguration.java
@@ -20,35 +20,36 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfiguration {
 
-    private final JwtAuthenticationFilter authenticationFilter;
+  private final JwtAuthenticationFilter authenticationFilter;
 
-    /**
-     * 보안을 체크하는 필터
-     *
-     * @param http
-     * @return
-     * @throws Exception
-     */
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session
-                        -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(
-                        authz -> authz.requestMatchers("/auth/signup","/auth/signupWithPartner", "/auth/signin").permitAll()
-                                .anyRequest().authenticated())
-                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
-        return http.build();
-    }
+  /**
+   * 보안을 체크하는 필터
+   *
+   * @param http
+   * @return
+   * @throws Exception
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(session
+            -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            authz -> authz.requestMatchers("/auth/signup", "/auth/signupWithPartner",
+                    "/auth/signin", "/chat", "/chat.html", "/ws/**", "/js/**").permitAll()
+                .anyRequest().authenticated())
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
 
-    /**
-     * localhost에서 오는 요청을 승인하는 메서드
-     *
-     * @return
-     */
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("localhost/**");
-    }
+  /**
+   * localhost에서 오는 요청을 승인하는 메서드
+   *
+   * @return
+   */
+  @Bean
+  public WebSecurityCustomizer webSecurityCustomizer() {
+    return (web) -> web.ignoring().requestMatchers("localhost/**");
+  }
 }

--- a/src/main/java/com/zerobase/together/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/together/security/TokenProvider.java
@@ -6,7 +6,6 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -19,78 +18,85 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class TokenProvider {
 
-    private static final long TOKEN_EXPIRE_TIME = 1000L * 60 * 60; // 1 hour
+  private static final long TOKEN_EXPIRE_TIME = 1000L * 60 * 60; // 1 hour
 
-    private final UserService userService;
+  private final UserService userService;
 
-    @Value("${jwt.secret}")
-    private String secretKey;
+  @Value("${jwt.secret}")
+  private String secretKey;
 
-    /**
-     * 토큰 생성(발급) 메서드
-     *
-     * @param userId
-     * @return
-     */
-    public String generateToken(String userId) {
-        Claims claims = Jwts.claims().setSubject(userId);
+  /**
+   * 토큰 생성(발급) 메서드
+   *
+   * @param userId
+   * @return
+   */
+  public String generateToken(String userId) {
+    Claims claims = Jwts.claims().setSubject(userId);
 
-        var now = new Date();
-        var expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+    var now = new Date();
+    var expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
 
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(expiredDate)
-                .signWith(SignatureAlgorithm.HS512, this.secretKey)
-                .compact();
+    return Jwts.builder()
+        .setClaims(claims)
+        .claim("coupleId", 123)
+        .setIssuedAt(now)
+        .setExpiration(expiredDate)
+        .signWith(SignatureAlgorithm.HS512, this.secretKey)
+        .compact();
+  }
+
+  /**
+   * 토큰을 통해 보안을 체크하는 메서드
+   *
+   * @param jwt
+   * @return 보안을 통해 확인된 인증
+   */
+  public Authentication getAuthentication(String jwt) {
+    UserDetails userDetails = this.userService.loadUserByUsername(this.getUsername(jwt));
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  /**
+   * 토큰에서 사용자 이름 꺼내는 메서드
+   *
+   * @param token
+   * @return 사용자 이름
+   */
+  public String getUsername(String token) {
+    return this.parseClaims(token).getSubject();
+  }
+
+  /**
+   * 토큰을 검증하는 메서드
+   *
+   * @param token
+   * @return 토큰 검증 결과
+   */
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return false;
     }
 
-    /**
-     * 토큰을 통해 보안을 체크하는 메서드
-     *
-     * @param jwt
-     * @return 보안을 통해 확인된 인증
-     */
-    public Authentication getAuthentication(String jwt) {
-        UserDetails userDetails = this.userService.loadUserByUsername(this.getUsername(jwt));
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-    }
+    var claims = this.parseClaims(token);
+    return !claims.getExpiration().before(new Date());
+  }
 
-    /**
-     * 토큰에서 사용자 이름 꺼내는 메서드
-     *
-     * @param token
-     * @return 사용자 이름
-     */
-    public String getUsername(String token) {
-        return this.parseClaims(token).getSubject();
+  /**
+   * 토큰에서 body 부분을 꺼내는 메서드
+   *
+   * @param token
+   * @return 토큰의 body
+   */
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
     }
+  }
 
-    /**
-     * 토큰을 검증하는 메서드
-     *
-     * @param token
-     * @return 토큰 검증 결과
-     */
-    public boolean validateToken(String token) {
-        if (!StringUtils.hasText(token)) return false;
-
-        var claims = this.parseClaims(token);
-        return !claims.getExpiration().before(new Date());
-    }
-
-    /**
-     * 토큰에서 body 부분을 꺼내는 메서드
-     *
-     * @param token
-     * @return 토큰의 body
-     */
-    private Claims parseClaims(String token) {
-        try {
-            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
-        }
-    }
+  public Long getCoupleId(String token) {
+    return this.parseClaims(token).get("coupleId", Long.class);
+  }
 }

--- a/src/main/java/com/zerobase/together/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/together/security/TokenProvider.java
@@ -92,7 +92,7 @@ public class TokenProvider {
     try {
       return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
     } catch (ExpiredJwtException e) {
-      return e.getClaims();
+      throw new RuntimeException("토큰 기간이 만료되었습니다.");
     }
   }
 

--- a/src/main/java/com/zerobase/together/service/ChatService.java
+++ b/src/main/java/com/zerobase/together/service/ChatService.java
@@ -1,0 +1,42 @@
+package com.zerobase.together.service;
+
+import com.zerobase.together.dto.ChatDto;
+import com.zerobase.together.dto.UserDto;
+import com.zerobase.together.entity.ChatEntity;
+import com.zerobase.together.repository.ChatRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+  private final ChatRepository chatRepository;
+
+  public ChatDto saveChat(ChatDto chatDto) {
+    this.chatRepository.save(ChatEntity.builder()
+        .coupleId(chatDto.getCoupleId())
+        .senderId(chatDto.getSenderId())
+        .content(chatDto.getContent())
+        .build());
+    return chatDto;
+  }
+
+  public List<ChatDto> getChats(int pageNum) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    UserDto userDto = (UserDto) userDetails;
+    Long coupleId = userDto.getCoupleId();
+    Pageable pageable = PageRequest.of(pageNum, 20);
+    Page<ChatEntity> result = this.chatRepository.findAllByCoupleIdOrderByCreatedDateTimeDesc(
+        coupleId, pageable);
+    return result.stream().map(ChatDto::toDto).toList();
+  }
+}

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Chat</title>
+</head>
+<body>
+<h2>Chat Room</h2>
+<div id="chat">
+  <ul id="messages"></ul>
+</div>
+<input type="text" id="coupleId" placeholder="Type your coupleId here..."/>
+<button onclick="connect()">Connect</button>
+
+<input type="text" id="message" placeholder="Type your message here..."/>
+<button onclick="sendMessage()">Send</button>
+
+<!-- SockJS 라이브러리 추가 -->
+<script src="https://cdn.jsdelivr.net/npm/sockjs-client@1.5.1/dist/sockjs.min.js"></script>
+<!-- STOMP 라이브러리 추가 -->
+<script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+
+<!-- JavaScript 파일 연결 -->
+<script src="/js/chat.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -1,0 +1,42 @@
+let stompClient = null;
+
+function connect() {
+  // WebSocket 연결을 위한 SockJS 및 STOMP 설정
+  const socket = new SockJS('/ws/chat'); // 서버 WebSocket 엔드포인트와 연결
+  stompClient = Stomp.over(socket);
+
+  // STOMP 연결
+  stompClient.connect({}, function () {
+    console.log('Connected to WebSocket');
+
+    // 메시지 구독
+    const coupleId = document.getElementById("coupleId").value;
+
+    stompClient.subscribe('/topic/messages/' + coupleId,
+        function (messageOutput) {
+          showMessage(JSON.parse(messageOutput.body)); // 수신된 메시지 표시
+        });
+  });
+}
+
+// 메시지 전송
+function sendMessage() {
+  const coupleId = document.getElementById("coupleId").value;
+  const messageContent = document.getElementById("message").value;
+  if (stompClient && messageContent) {
+    stompClient.send("/app/send", {},
+        JSON.stringify(
+            {coupleId: coupleId, senderId: "user1", content: messageContent}));
+    document.getElementById("message").value = ''; // 전송 후 입력창 초기화
+  }
+}
+
+// 수신된 메시지를 화면에 표시
+function showMessage(message) {
+  const messageElement = document.createElement('li');
+  messageElement.innerText = message.content; // 수신된 메시지 내용 표시
+  document.getElementById("messages").appendChild(messageElement);
+}
+
+// 페이지 로딩 시 WebSocket 연결
+window.onload = connect;


### PR DESCRIPTION
…정 변경, jwt토큰에 커플Id 추가

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

**AS-IS**
같은 커플 번호를 가진 사람끼리 채팅할 수 있는 기능을 추가했습니다.
채팅 Entity는 id,coupleId,senderId,content,createdDateTime으로 이루어져 있습니다.
Http 연결시 토큰 사용자의 커플Id를 확인해 해당 채팅 내역을 불러 올 수 있고 채팅을 보낼 때도 해당 커플Id의 subscriber에게 보낼 수 있습니다.
사용자의 커플Id에 속하는 채팅 내역이 페이징 처리되서 20개씩 불러올 수 있습니다.

**TO-BE**
테스트하다보니 잘되다가 채팅방에 본인이 보낸 채팅이 두번씩 찍히는 경우가 있었는데 원인을 잘몰라서 찾아봐야할 것 같습니다.
jwt토큰에 넣은 coupleId를 이용해 게시글,코멘트에서도 불필요한 과정을 줄일 수 있을 것 같습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] API 테스트 : 간단한 웹페이지를 통해 채팅이 가능한 것을 확인하였고 포스트맨을 통해 채팅내역이 불러와지는 것을 확인했습니다.