### PR TITLE
feat: s3를 이용한 사진 앨범, 채팅으로 사진을 보내는 기능 추가

### DIFF
--- a/src/main/java/com/zerobase/together/TogetherApplication.java
+++ b/src/main/java/com/zerobase/together/TogetherApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class TogetherApplication {
 

--- a/src/main/java/com/zerobase/together/component/WebSocketEventListener.java
+++ b/src/main/java/com/zerobase/together/component/WebSocketEventListener.java
@@ -1,0 +1,37 @@
+package com.zerobase.together.component;
+
+import com.zerobase.together.service.UserService;
+import com.zerobase.together.service.WebSocketSessionService;
+import lombok.AllArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@AllArgsConstructor
+public class WebSocketEventListener {
+
+  private WebSocketSessionService webSocketSessionService;
+  private UserService userService;
+
+  // 연결 시 이벤트
+  @EventListener
+  public void handleWebSocketConnectListener(SessionConnectEvent event) {
+    StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+    String sessionId = headerAccessor.getSessionId();
+    String username = this.userService.getUsername();
+    if (username != null) {
+      webSocketSessionService.addSession(sessionId, username);
+    }
+  }
+
+  // 연결 해제 시 이벤트
+  @EventListener
+  public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+    String sessionId = event.getSessionId();
+    webSocketSessionService.removeSession(sessionId);
+  }
+
+}

--- a/src/main/java/com/zerobase/together/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/zerobase/together/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.zerobase.together.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/src/main/java/com/zerobase/together/config/S3Config.java
+++ b/src/main/java/com/zerobase/together/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.zerobase.together.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class S3Config {
+
+  @Value("${cloud.aws.credentials.accessKey}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secretKey}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3Client amazonS3Client() {
+    BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,
+        secretKey);
+    return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/together/controller/ChatController.java
+++ b/src/main/java/com/zerobase/together/controller/ChatController.java
@@ -2,7 +2,7 @@ package com.zerobase.together.controller;
 
 import com.zerobase.together.dto.ChatDto;
 import com.zerobase.together.service.ChatService;
-import com.zerobase.together.service.PhotoService;
+import com.zerobase.together.service.WebSocketSessionService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +19,7 @@ public class ChatController {
 
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatService chatService;
-  private final PhotoService photoService;
+  private final WebSocketSessionService webSocketSessionService;
 
   @MessageMapping("/send") // 클라이언트가 /app/send로 보낸 메시지를 수신
   @SendTo("/topic/messages") // 구독자에게 /topic/messages로 메시지를 브로드캐스트
@@ -38,5 +38,10 @@ public class ChatController {
   @GetMapping("/chat")
   public String chatPage() {
     return "chat.html";
+  }
+
+  @GetMapping("/partner")
+  public ResponseEntity<?> checkPartnerConnect() {
+    return ResponseEntity.ok(this.webSocketSessionService.isPartnerConnected());
   }
 }

--- a/src/main/java/com/zerobase/together/controller/ChatController.java
+++ b/src/main/java/com/zerobase/together/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.zerobase.together.controller;
 
 import com.zerobase.together.dto.ChatDto;
 import com.zerobase.together.service.ChatService;
+import com.zerobase.together.service.PhotoService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ public class ChatController {
 
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatService chatService;
+  private final PhotoService photoService;
 
   @MessageMapping("/send") // 클라이언트가 /app/send로 보낸 메시지를 수신
   @SendTo("/topic/messages") // 구독자에게 /topic/messages로 메시지를 브로드캐스트

--- a/src/main/java/com/zerobase/together/controller/PhotoController.java
+++ b/src/main/java/com/zerobase/together/controller/PhotoController.java
@@ -5,7 +5,6 @@ import com.zerobase.together.service.PhotoService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,8 +21,8 @@ public class PhotoController {
   private final PhotoService photoService;
 
   @PostMapping
-  public ResponseEntity<String> savePhoto(@RequestParam("file") MultipartFile file) {
-    return ResponseEntity.ok(photoService.save(file));
+  public String savePhoto(@RequestParam("file") MultipartFile file) {
+    return photoService.save(file);
   }
 
   @PostMapping("/list")

--- a/src/main/java/com/zerobase/together/controller/PhotoController.java
+++ b/src/main/java/com/zerobase/together/controller/PhotoController.java
@@ -1,0 +1,43 @@
+package com.zerobase.together.controller;
+
+import com.zerobase.together.dto.PhotoDto;
+import com.zerobase.together.service.PhotoService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/photo")
+@RequiredArgsConstructor
+public class PhotoController {
+
+  private final PhotoService photoService;
+
+  @PostMapping
+  public ResponseEntity<String> savePhoto(@RequestParam("file") MultipartFile file) {
+    return ResponseEntity.ok(photoService.save(file));
+  }
+
+  @PostMapping("/list")
+  public void savePhotos(@RequestParam("files") MultipartFile[] files) {
+    photoService.savePhotos(List.of(files));
+  }
+
+  @GetMapping
+  public Page<PhotoDto> showPhotos(@RequestParam Integer pageNum) {
+    return photoService.showPhotos(pageNum);
+  }
+
+  @DeleteMapping
+  public void deleteFile(@RequestParam("fileName") String fileName) {
+    photoService.delete(fileName);
+  }
+}

--- a/src/main/java/com/zerobase/together/dto/AuthDto.java
+++ b/src/main/java/com/zerobase/together/dto/AuthDto.java
@@ -2,11 +2,13 @@ package com.zerobase.together.dto;
 
 import com.zerobase.together.entity.UserEntity;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Data;
 
 public class AuthDto {
 
   @Data
+  @Builder
   public static class SignIn {
 
     private String username;
@@ -14,6 +16,7 @@ public class AuthDto {
   }
 
   @Data
+  @Builder
   public static class SignUp {
 
     private String username;
@@ -35,6 +38,7 @@ public class AuthDto {
   }
 
   @Data
+  @Builder
   public static class SignUpWithPartner {
 
     private String username;

--- a/src/main/java/com/zerobase/together/dto/ChatDto.java
+++ b/src/main/java/com/zerobase/together/dto/ChatDto.java
@@ -17,6 +17,7 @@ public class ChatDto {
 
   private Long coupleId;
   private String senderId;
+  private String imgUrl;
   private String content;
   private LocalDateTime createdDateTime;
 
@@ -24,6 +25,7 @@ public class ChatDto {
     return ChatDto.builder()
         .coupleId(chatEntity.getCoupleId())
         .senderId(chatEntity.getSenderId())
+        .imgUrl(chatEntity.getImgUrl())
         .content(chatEntity.getContent())
         .createdDateTime(chatEntity.getCreatedDateTime())
         .build();

--- a/src/main/java/com/zerobase/together/dto/ErrorResponse.java
+++ b/src/main/java/com/zerobase/together/dto/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.zerobase.together.dto;
+
+import com.zerobase.together.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+
+  private ErrorCode errorCode;
+  private String errorMessage;
+}

--- a/src/main/java/com/zerobase/together/dto/PhotoDto.java
+++ b/src/main/java/com/zerobase/together/dto/PhotoDto.java
@@ -1,0 +1,29 @@
+package com.zerobase.together.dto;
+
+import com.zerobase.together.entity.PhotoEntity;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PhotoDto {
+
+  private Long photoId;
+  private Long coupleId;
+  private Long userId;
+  private String imgUrl;
+  private LocalDateTime createdDateTime;
+
+  public static PhotoDto toDto(PhotoEntity photoEntity, String urlPrefix) {
+    return PhotoDto.builder()
+        .photoId(photoEntity.getId())
+        .coupleId(photoEntity.getCoupleId())
+        .userId(photoEntity.getUserId())
+        .imgUrl(urlPrefix + photoEntity.getImgUrl())
+        .createdDateTime(photoEntity.getCreatedDateTime())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/together/dto/UserDto.java
+++ b/src/main/java/com/zerobase/together/dto/UserDto.java
@@ -18,12 +18,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Builder
 public class UserDto implements UserDetails {
 
+  private Long id;
   private Long coupleId;
   private String username;
 
 
   public static UserDto fromEntity(UserEntity userEntity) {
     return UserDto.builder()
+        .id(userEntity.getId())
         .coupleId(userEntity.getCoupleId())
         .username(userEntity.getUsername())
         .build();

--- a/src/main/java/com/zerobase/together/entity/ChatEntity.java
+++ b/src/main/java/com/zerobase/together/entity/ChatEntity.java
@@ -1,5 +1,6 @@
 package com.zerobase.together.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -28,6 +29,8 @@ public class ChatEntity {
   private Long id;
   private Long coupleId;
   private String senderId;
+  @Column(length = 512)
+  private String imgUrl;
   private String content;
   @CreatedDate
   private LocalDateTime createdDateTime;

--- a/src/main/java/com/zerobase/together/entity/PhotoEntity.java
+++ b/src/main/java/com/zerobase/together/entity/PhotoEntity.java
@@ -12,20 +12,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Builder
 @Getter
 @Setter
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Entity(name = "post")
+@Entity(name = "photo")
 @EntityListeners(AuditingEntityListener.class)
-public class PostEntity {
+public class PhotoEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,11 +31,6 @@ public class PostEntity {
   private Long userId;
   @Column(length = 512)
   private String imgUrl;
-  @Column(columnDefinition = "TEXT")
-  private String description;
   @CreatedDate
   private LocalDateTime createdDateTime;
-  @LastModifiedDate
-  private LocalDateTime modifiedDateTime;
-  private LocalDateTime deletedDateTime;
 }

--- a/src/main/java/com/zerobase/together/exception/AuthorityException.java
+++ b/src/main/java/com/zerobase/together/exception/AuthorityException.java
@@ -1,0 +1,24 @@
+package com.zerobase.together.exception;
+
+import com.zerobase.together.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthorityException extends RuntimeException {
+
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+  public AuthorityException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+}

--- a/src/main/java/com/zerobase/together/exception/CustomException.java
+++ b/src/main/java/com/zerobase/together/exception/CustomException.java
@@ -1,0 +1,24 @@
+package com.zerobase.together.exception;
+
+import com.zerobase.together.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomException extends RuntimeException {
+
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+  public CustomException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+}

--- a/src/main/java/com/zerobase/together/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/together/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.zerobase.together.exception;
+
+import static com.zerobase.together.type.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import com.zerobase.together.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    log.error("{} is occurred", e.getErrorCode());
+    return new ResponseEntity<>(new ErrorResponse(e.getErrorCode(), e.getErrorMessage()),
+        HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(AuthorityException.class)
+  public ResponseEntity<ErrorResponse> handleAuthorityException(AuthorityException e) {
+    log.error("{} is occurred", e.getErrorCode());
+    return new ResponseEntity<>(new ErrorResponse(e.getErrorCode(), e.getErrorMessage()),
+        HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("Error is occurred", e);
+    return new ResponseEntity<>(new ErrorResponse(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR
+        .getDescription()), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/src/main/java/com/zerobase/together/repository/PhotoRepository.java
+++ b/src/main/java/com/zerobase/together/repository/PhotoRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.together.repository;
+
+import com.zerobase.together.entity.PhotoEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoRepository extends JpaRepository<PhotoEntity, Long> {
+
+  Page<PhotoEntity> findAllByCoupleIdOrderByCoupleIdDesc(Long coupleId, Pageable pageable);
+}

--- a/src/main/java/com/zerobase/together/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/together/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findByUsername(String username);
 
   boolean existsByUsername(String username);
+
+  Optional<UserEntity> findByCoupleIdAndUsernameNot(Long coupleId, String username);
 }

--- a/src/main/java/com/zerobase/together/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/together/security/SecurityConfiguration.java
@@ -37,7 +37,7 @@ public class SecurityConfiguration {
             -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             authz -> authz.requestMatchers("/auth/signup", "/auth/signupWithPartner",
-                    "/auth/signin", "/chat", "/chat.html", "/ws/**", "/js/**").permitAll()
+                    "/auth/signin", "/chat", "/chat.html", "/ws/**", "/js/**", "/photo").permitAll()
                 .anyRequest().authenticated())
         .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();

--- a/src/main/java/com/zerobase/together/service/ChatService.java
+++ b/src/main/java/com/zerobase/together/service/ChatService.java
@@ -4,7 +4,6 @@ import com.zerobase.together.dto.ChatDto;
 import com.zerobase.together.dto.UserDto;
 import com.zerobase.together.entity.ChatEntity;
 import com.zerobase.together.repository.ChatRepository;
-import com.zerobase.together.repository.PhotoRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
   private final ChatRepository chatRepository;
-  private final PhotoService photoService;
 
   @Transactional
   public ChatDto saveChat(ChatDto chatDto) {

--- a/src/main/java/com/zerobase/together/service/ChatService.java
+++ b/src/main/java/com/zerobase/together/service/ChatService.java
@@ -4,6 +4,7 @@ import com.zerobase.together.dto.ChatDto;
 import com.zerobase.together.dto.UserDto;
 import com.zerobase.together.entity.ChatEntity;
 import com.zerobase.together.repository.ChatRepository;
+import com.zerobase.together.repository.PhotoRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,17 +14,21 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ChatService {
 
   private final ChatRepository chatRepository;
+  private final PhotoService photoService;
 
+  @Transactional
   public ChatDto saveChat(ChatDto chatDto) {
     this.chatRepository.save(ChatEntity.builder()
         .coupleId(chatDto.getCoupleId())
         .senderId(chatDto.getSenderId())
+        .imgUrl(chatDto.getImgUrl())
         .content(chatDto.getContent())
         .build());
     return chatDto;

--- a/src/main/java/com/zerobase/together/service/HistoryService.java
+++ b/src/main/java/com/zerobase/together/service/HistoryService.java
@@ -1,19 +1,15 @@
 package com.zerobase.together.service;
 
 import com.zerobase.together.dto.HistoryDto;
+import com.zerobase.together.dto.UserDto;
 import com.zerobase.together.entity.HistoryEntity;
-import com.zerobase.together.entity.UserEntity;
 import com.zerobase.together.repository.HistoryRepository;
-import com.zerobase.together.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -22,7 +18,7 @@ import org.springframework.stereotype.Service;
 public class HistoryService {
 
   private final HistoryRepository historyRepository;
-  private final UserRepository userRepository;
+  private final UserService userService;
 
   public void createHistory(HistoryDto historyDto) {
     this.historyRepository.save(HistoryEntity.builder()
@@ -37,7 +33,7 @@ public class HistoryService {
   }
 
   public List<HistoryDto> readHistory(Integer pageNum) {
-    UserEntity user = getLoginUser();
+    UserDto user = this.userService.getLoginUser();
     Pageable pageable = PageRequest.of(pageNum, 10);
     Page<HistoryEntity> result = historyRepository.findAllByCoupleIdOrderByCreatedDateTimeDesc(
         user.getCoupleId(),
@@ -52,10 +48,4 @@ public class HistoryService {
     return content.substring(0, 10) + "...";
   }
 
-  private UserEntity getLoginUser() {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-    return this.userRepository.findByUsername(userDetails.getUsername())
-        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
-  }
 }

--- a/src/main/java/com/zerobase/together/service/PhotoService.java
+++ b/src/main/java/com/zerobase/together/service/PhotoService.java
@@ -1,0 +1,102 @@
+package com.zerobase.together.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.zerobase.together.dto.PhotoDto;
+import com.zerobase.together.dto.UserDto;
+import com.zerobase.together.entity.PhotoEntity;
+import com.zerobase.together.entity.UserEntity;
+import com.zerobase.together.repository.PhotoRepository;
+import com.zerobase.together.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoService {
+
+  private final PhotoRepository photoRepository;
+  private final UserRepository userRepository;
+  private final AmazonS3Client amazonS3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  private String urlPrefix;
+
+  @PostConstruct
+  public void init() {
+    urlPrefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+  }
+
+  @Transactional
+  public String save(MultipartFile file) {
+    UserEntity user = getLoginUser();
+    try {
+      String fileName = file.getOriginalFilename();
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setContentType(file.getContentType());
+      metadata.setContentLength(file.getSize());
+      if (amazonS3Client.doesObjectExist(bucket, user.getCoupleId() + "/" + fileName)) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT, "File already exists");
+      }
+      this.amazonS3Client.putObject(bucket, user.getCoupleId() + "/" + fileName,
+          file.getInputStream(),
+          metadata);
+      this.photoRepository.save(PhotoEntity.builder()
+          .coupleId(user.getCoupleId())
+          .userId(user.getId())
+          .imgUrl(user.getCoupleId() + "/" + fileName)
+          .build());
+      return urlPrefix + user.getCoupleId() + "/" + fileName;
+    } catch (Exception e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+  }
+
+  @Transactional
+  public void savePhotos(List<MultipartFile> files) {
+    for (MultipartFile file : files) {
+      this.save(file);
+    }
+  }
+
+  public Page<PhotoDto> showPhotos(Integer pageNum) {
+    Pageable pageable = PageRequest.of(pageNum, 10);
+    return this.photoRepository.findAllByCoupleIdOrderByCoupleIdDesc(
+        getCoupleId(), pageable).map(photoEntity -> PhotoDto.toDto(photoEntity, urlPrefix));
+  }
+
+  public void delete(String fileUrl) {
+    this.amazonS3Client.deleteObject(bucket, fileUrl.substring(urlPrefix.length()));
+  }
+
+  private Long getCoupleId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDto userDto = (UserDto) authentication.getPrincipal();
+    return userDto.getCoupleId();
+  }
+
+  private UserEntity getLoginUser() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    return this.userRepository.findByUsername(userDetails.getUsername())
+        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+  }
+
+}

--- a/src/main/java/com/zerobase/together/service/PostService.java
+++ b/src/main/java/com/zerobase/together/service/PostService.java
@@ -1,9 +1,14 @@
 package com.zerobase.together.service;
 
+import static com.zerobase.together.type.ErrorCode.INVALID_POST;
+import static com.zerobase.together.type.ErrorCode.UNAUTHORIZED;
+
 import com.zerobase.together.dto.HistoryDto;
 import com.zerobase.together.dto.PostDto;
 import com.zerobase.together.dto.UserDto;
 import com.zerobase.together.entity.PostEntity;
+import com.zerobase.together.exception.AuthorityException;
+import com.zerobase.together.exception.CustomException;
 import com.zerobase.together.repository.PostRepository;
 import com.zerobase.together.type.HistoryAction;
 import com.zerobase.together.type.HistoryTarget;
@@ -49,12 +54,12 @@ public class PostService {
   public PostDto readPost(Long postId) {
     UserDto user = this.userService.getLoginUser();
     PostEntity postEntity = this.postRepository.findById(postId)
-        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+        .orElseThrow(() -> new CustomException(INVALID_POST));
     if (postEntity.getCoupleId() != user.getCoupleId()) {
-      throw new RuntimeException("포스트를 읽을 권한이 없습니다.");
+      throw new AuthorityException(UNAUTHORIZED);
     }
     if (postEntity.getDeletedDateTime() != null) {
-      throw new RuntimeException("삭제된 게시글입니다.");
+      throw new CustomException(INVALID_POST);
     }
     return PostDto.toDto(postEntity);
   }
@@ -71,12 +76,12 @@ public class PostService {
   public PostDto updatePost(PostDto post) {
     UserDto user = this.userService.getLoginUser();
     PostEntity postEntity = this.postRepository.findById(post.getPostId())
-        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+        .orElseThrow(() -> new CustomException(INVALID_POST));
     if (postEntity.getUserId() != user.getId()) {
-      throw new RuntimeException("포스트 작성자가 아닙니다.");
+      throw new AuthorityException(UNAUTHORIZED);
     }
     if (postEntity.getDeletedDateTime() != null) {
-      throw new RuntimeException("삭제된 게시글입니다.");
+      throw new CustomException(INVALID_POST);
     }
     postEntity.setImgUrl(post.getImgUrl());
     postEntity.setDescription(post.getDescription());
@@ -95,12 +100,12 @@ public class PostService {
   public void deletePost(Long postId) {
     UserDto user = this.userService.getLoginUser();
     PostEntity postEntity = this.postRepository.findById(postId)
-        .orElseThrow(() -> new RuntimeException("해당 포스트가 존재하지 않습니다."));
+        .orElseThrow(() -> new CustomException(INVALID_POST));
     if (user.getId() != postEntity.getUserId()) {
-      throw new RuntimeException("포스트 작성자가 아닙니다.");
+      throw new AuthorityException(UNAUTHORIZED);
     }
     if (postEntity.getDeletedDateTime() != null) {
-      throw new RuntimeException("삭제된 게시글입니다.");
+      throw new CustomException(INVALID_POST);
     }
     postEntity.setDeletedDateTime(LocalDateTime.now());
     this.postRepository.save(postEntity);

--- a/src/main/java/com/zerobase/together/service/UserService.java
+++ b/src/main/java/com/zerobase/together/service/UserService.java
@@ -1,10 +1,19 @@
 package com.zerobase.together.service;
 
+import static com.zerobase.together.type.ErrorCode.INVALID_COUPLE_ID;
+import static com.zerobase.together.type.ErrorCode.INVALID_PARTNER_NAME;
+import static com.zerobase.together.type.ErrorCode.INVALID_USER_NAME;
+import static com.zerobase.together.type.ErrorCode.PARTNER_ALREADY_COUPLE;
+import static com.zerobase.together.type.ErrorCode.PARTNER_NOT_FOUND;
+import static com.zerobase.together.type.ErrorCode.PASSWORD_UN_MATCH;
+import static com.zerobase.together.type.ErrorCode.USERNAME_ALREADY_EXISTS;
+
 import com.zerobase.together.dto.AuthDto;
 import com.zerobase.together.dto.AuthDto.SignUpWithPartner;
 import com.zerobase.together.dto.UserDto;
 import com.zerobase.together.entity.CoupleEntity;
 import com.zerobase.together.entity.UserEntity;
+import com.zerobase.together.exception.CustomException;
 import com.zerobase.together.repository.CoupleRepository;
 import com.zerobase.together.repository.UserRepository;
 import lombok.AllArgsConstructor;
@@ -35,7 +44,7 @@ public class UserService implements UserDetailsService {
   public UserDto register(AuthDto.SignUp user) {
 
     if (this.userRepository.existsByUsername(user.getUsername())) {
-      throw new RuntimeException("이미 사용중인 아이디 입니다. -> " + user.getUsername());
+      throw new CustomException(USERNAME_ALREADY_EXISTS);
     }
 
     CoupleEntity coupleEntity = coupleRepository.save(new CoupleEntity());
@@ -54,16 +63,16 @@ public class UserService implements UserDetailsService {
    */
   public UserDto registerWithPartner(SignUpWithPartner user) {
     if (this.userRepository.existsByUsername(user.getUsername())) {
-      throw new RuntimeException("이미 사용중인 아이디 입니다. -> " + user.getUsername());
+      throw new CustomException(USERNAME_ALREADY_EXISTS);
     }
 
     UserEntity partner = this.userRepository.findByUsername(user.getPartnername())
         .orElseThrow(
-            () -> new UsernameNotFoundException("파트너가 존재하지 않습니다. -> " + user.getPartnername()));
+            () -> new CustomException(INVALID_PARTNER_NAME));
     CoupleEntity coupleEntity = this.coupleRepository.findById(partner.getCoupleId())
-        .orElseThrow(() -> new RuntimeException("존재하지 않는 커플아이디입니다."));
+        .orElseThrow(() -> new CustomException(INVALID_COUPLE_ID));
     if (coupleEntity.isAuthorized()) {
-      throw new RuntimeException("상대방은 이미 커플입니다.");
+      throw new CustomException(PARTNER_ALREADY_COUPLE);
     }
     user.setCoupleId(partner.getCoupleId());
     user.setPassword(this.passwordEncoder.encode(user.getPassword()));
@@ -82,17 +91,17 @@ public class UserService implements UserDetailsService {
    */
   public UserDto authenticate(AuthDto.SignIn loginUser) {
     var user = this.userRepository.findByUsername(loginUser.getUsername())
-        .orElseThrow(() -> new RuntimeException("존재하지 않는 ID 입니다."));
+        .orElseThrow(() -> new CustomException(INVALID_USER_NAME));
 
     if (!this.passwordEncoder.matches(loginUser.getPassword(), user.getPassword())) {
-      throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+      throw new CustomException(PASSWORD_UN_MATCH);
     }
 
     CoupleEntity coupleEntity = coupleRepository.findById(user.getCoupleId())
-        .orElseThrow(() -> new RuntimeException("커플아이디가 존재하지 않습니다. -> " + user.getCoupleId()));
+        .orElseThrow(() -> new CustomException(INVALID_COUPLE_ID));
 
     if (!coupleEntity.isAuthorized()) {
-      throw new RuntimeException("상대방이 가입하지 않았습니다.");
+      throw new CustomException(PARTNER_NOT_FOUND);
     }
 
     return UserDto.fromEntity(user);
@@ -101,14 +110,14 @@ public class UserService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
     return UserDto.fromEntity(this.userRepository.findByUsername(userId)
-        .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다.")));
+        .orElseThrow(() -> new CustomException(INVALID_USER_NAME)));
   }
 
   public UserDto getLoginUser() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();
     return UserDto.fromEntity(this.userRepository.findByUsername(userDetails.getUsername())
-        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다.")));
+        .orElseThrow(() -> new CustomException(INVALID_USER_NAME)));
   }
 
   public String getUsername() {
@@ -125,9 +134,9 @@ public class UserService implements UserDetailsService {
 
   public String getPartnerName(String username) {
     UserEntity user = this.userRepository.findByUsername(username)
-        .orElseThrow(() -> new RuntimeException("해당 유저가 존재하지 않습니다."));
+        .orElseThrow(() -> new CustomException(INVALID_USER_NAME));
     UserEntity partner = this.userRepository.findByCoupleIdAndUsernameNot(user.getCoupleId(),
-        username).orElseThrow(() -> new RuntimeException("파트너가 존재하지 않습니다."));
+        username).orElseThrow(() -> new CustomException(PARTNER_NOT_FOUND));
     return partner.getUsername();
   }
 }

--- a/src/main/java/com/zerobase/together/service/WebSocketSessionService.java
+++ b/src/main/java/com/zerobase/together/service/WebSocketSessionService.java
@@ -1,0 +1,38 @@
+package com.zerobase.together.service;
+
+import com.zerobase.together.dto.UserDto;
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class WebSocketSessionService {
+
+  private final UserService userService;
+  private final RedisTemplate<String, String> redisTemplate;
+  private static final String PREFIX = "WS_SESSION:";
+
+  // 사용자 접속 상태를 Redis에 저장
+  public void addSession(String sessionId, String userId) {
+    redisTemplate.opsForValue().set(PREFIX + sessionId, userId);
+  }
+
+  // 사용자 접속 해제 시 Redis에서 삭제
+  public void removeSession(String sessionId) {
+    redisTemplate.delete(PREFIX + sessionId);
+  }
+
+  // 로그인된 사용자 이름 기준으로 파트너 접속 확인
+  public boolean isPartnerConnected() {
+    UserDto user = this.userService.getLoginUser();
+    return isUserConnected(this.userService.getPartnerName(user.getUsername()));
+  }
+
+  // 현재 접속 여부 확인
+  public boolean isUserConnected(String username) {
+    return redisTemplate.keys(PREFIX + "*").stream()
+        .anyMatch(key -> redisTemplate.opsForValue().get(key).equals(username));
+  }
+
+}

--- a/src/main/java/com/zerobase/together/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/together/type/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.zerobase.together.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  INVALID_PARTNER_NAME("존재하지 않는 파트너입니다."),
+  INVALID_COUPLE_ID("존재하지 않는 커플아이디입니다."),
+  INVALID_USER_NAME("존재하지 않는 유저명입니다."),
+  INVALID_POST("해당 포스트가 존재하지 않습니다."),
+  INVALID_COMMENT("해당 댓글이 존재하지 않습니다."),
+  PASSWORD_UN_MATCH("비밀번호가 일치하지 않습니다."),
+  USERNAME_ALREADY_EXISTS("이미 사용중인 유저명입니다."),
+  PARTNER_ALREADY_COUPLE("상대방은 이미 커플입니다."),
+  PARTNER_NOT_FOUND("상대방이 가입하지 않았습니다."),
+  UNAUTHORIZED("권한이 없습니다."),
+  INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.");
+  private final String description;
+}

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -14,6 +14,7 @@
 <button onclick="connect()">Connect</button>
 
 <input type="text" id="message" placeholder="Type your message here..."/>
+<input type="file" id="fileInput" />
 <button onclick="sendMessage()">Send</button>
 
 <!-- SockJS 라이브러리 추가 -->

--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -26,7 +26,7 @@ function sendMessage() {
   if (stompClient && messageContent) {
     stompClient.send("/app/send", {},
         JSON.stringify(
-            {coupleId: coupleId, senderId: "user1", content: messageContent}));
+            {coupleId: coupleId, senderId: "user1", content: messageContent, imgUrl:null}));
     document.getElementById("message").value = ''; // 전송 후 입력창 초기화
   }
 }

--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -20,13 +20,41 @@ function connect() {
 }
 
 // 메시지 전송
-function sendMessage() {
+async function sendMessage() {
   const coupleId = document.getElementById("coupleId").value;
   const messageContent = document.getElementById("message").value;
+  const fileInput = document.getElementById("fileInput").files[0];
+  let fileUrl = null;
+
+  // 파일이 선택된 경우 업로드
+  if (fileInput) {
+    const formData = new FormData();
+    formData.append("file", fileInput);
+    const token = "token";
+    // 파일 업로드 요청
+    try {
+      const response = await fetch("/photo", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer " + token
+        },
+        body: formData,
+      });
+      fileUrl = await response.text(); // 업로드된 파일의 URL을 가져옴
+    } catch (error) {
+      console.error("File upload failed:", error);
+      return;
+    }
+  }
   if (stompClient && messageContent) {
     stompClient.send("/app/send", {},
         JSON.stringify(
-            {coupleId: coupleId, senderId: "user1", content: messageContent, imgUrl:null}));
+            {
+              coupleId: coupleId,
+              senderId: "user1",
+              content: messageContent,
+              imgUrl: fileUrl
+            }));
     document.getElementById("message").value = ''; // 전송 후 입력창 초기화
   }
 }
@@ -35,6 +63,16 @@ function sendMessage() {
 function showMessage(message) {
   const messageElement = document.createElement('li');
   messageElement.innerText = message.content; // 수신된 메시지 내용 표시
+  if (message.imgUrl) {
+    const imgElement = document.createElement('img');
+    imgElement.src = message.imgUrl;
+    imgElement.alt = "Image"; // 이미지 설명 (옵션)
+    imgElement.style.maxWidth = "200px"; // 이미지 크기 조절
+    imgElement.style.display = "block";
+    imgElement.style.marginTop = "5px";
+
+    messageElement.appendChild(imgElement);
+  }
   document.getElementById("messages").appendChild(messageElement);
 }
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
s3를 이용해 커플아이디 별로 사진을 저장할 수 있습니다. 앨범 사진들을 불러올때는 해당 유저의 커플아이디를 가진 사진들을 최근 시간부터 역순으로 페이징처리되서 불러와집니다. 또 채팅 Entity에 imgUrl을 추가해서 채팅을 통해 사진을 보낼 수 있습니다.
WebSocket에 연결할 경우 세션ID를 주어서 Redis서버에 {세션Id:username} 형태로 저장하고 연결이 끊길 경우에는 다시 삭제해 커플이 접속해있는지 확인할 수 있습니다.

**TO-BE**
현재는 s3가 public read가 허용되었기 때문에 보안적으로 취약해서 private read로 바꿨을때 client에서 어떻게 사진을 확인할 수 있는지 방법을 찾아야 합니다.
임시 채팅 페이지도 사진을 보내는 것이 구현되지 않아 추후 수정이 필요합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] API 테스트: 포스트맨을 통해 관련 api들이 정상적으로 작동하는 것을 확인했습니다.